### PR TITLE
Fixed reading of PNTS files with RTC_CENTER

### DIFF
--- a/pasture-core/src/containers/mod.rs
+++ b/pasture-core/src/containers/mod.rs
@@ -33,6 +33,5 @@ pub use self::vec_buffers::*;
 mod slice_buffers;
 pub use self::slice_buffers::*;
 
-
 mod untyped_point;
 pub use self::untyped_point::*;

--- a/pasture-core/src/layout/conversion.rs
+++ b/pasture-core/src/layout/conversion.rs
@@ -195,18 +195,32 @@ fn get_color_rgb_converter(
     COLOR_RGB_CONVERTERS.get(&key).map(|&fptr| fptr)
 }
 
-macro_rules! insert_converter {
+macro_rules! insert_converter_using_into {
     ($prim_from:ident, $prim_to:ident, $type_from:ident, $type_to:ident, $map:expr) => {
         ($map).insert(
             (
                 PointAttributeDataType::$type_from,
                 PointAttributeDataType::$type_to,
             ),
-            convert_generic_primitive::<$prim_from, $prim_to>,
+            convert_using_into::<$prim_from, $prim_to>,
         )
     };
 }
 
+macro_rules! insert_converter_using_as {
+    ($type_from:ident, $type_to:ident, $convert_fn:ident, $map:expr) => {
+        ($map).insert(
+            (
+                PointAttributeDataType::$type_from,
+                PointAttributeDataType::$type_to,
+            ),
+            $convert_fn,
+        )
+    };
+}
+
+/// Returns a generic converter that can convert between primitive types. Going from smaller to larger types is realized
+/// through `.into()` calls, while going from larger to smaller types is done through coercions (using `as`) where possible
 fn get_generic_converter(
     from_type: PointAttributeDataType,
     to_type: PointAttributeDataType,
@@ -217,19 +231,35 @@ fn get_generic_converter(
                 (PointAttributeDataType, PointAttributeDataType),
                 AttributeConversionFn,
             >::new();
-            insert_converter!(u8, u16, U8, U16, converters);
-            insert_converter!(u8, u32, U8, U32, converters);
-            insert_converter!(u8, u64, U8, U64, converters);
-            insert_converter!(u16, u32, U16, U32, converters);
-            insert_converter!(u16, u64, U16, U64, converters);
-            insert_converter!(u32, u64, U32, U64, converters);
+            insert_converter_using_into!(u8, u16, U8, U16, converters);
+            insert_converter_using_into!(u8, u32, U8, U32, converters);
+            insert_converter_using_into!(u8, u64, U8, U64, converters);
+            insert_converter_using_into!(u16, u32, U16, U32, converters);
+            insert_converter_using_into!(u16, u64, U16, U64, converters);
+            insert_converter_using_into!(u32, u64, U32, U64, converters);
 
-            insert_converter!(i8, i16, I8, I16, converters);
-            insert_converter!(i8, i32, I8, I32, converters);
-            insert_converter!(i8, i64, I8, I64, converters);
-            insert_converter!(i16, i32, I16, I32, converters);
-            insert_converter!(i16, i64, I16, I64, converters);
-            insert_converter!(i32, i64, I32, I64, converters);
+            insert_converter_using_into!(i8, i16, I8, I16, converters);
+            insert_converter_using_into!(i8, i32, I8, I32, converters);
+            insert_converter_using_into!(i8, i64, I8, I64, converters);
+            insert_converter_using_into!(i16, i32, I16, I32, converters);
+            insert_converter_using_into!(i16, i64, I16, I64, converters);
+            insert_converter_using_into!(i32, i64, I32, I64, converters);
+
+            insert_converter_using_as!(U16, U8, convert_u16_to_u8, converters);
+            insert_converter_using_as!(U32, U8, convert_u32_to_u8, converters);
+            insert_converter_using_as!(U64, U8, convert_u64_to_u8, converters);
+            insert_converter_using_as!(U32, U16, convert_u32_to_u16, converters);
+            insert_converter_using_as!(U64, U16, convert_u64_to_u16, converters);
+            insert_converter_using_as!(U64, U32, convert_u64_to_u32, converters);
+
+            insert_converter_using_as!(I16, I8, convert_i16_to_i8, converters);
+            insert_converter_using_as!(I32, I8, convert_i32_to_i8, converters);
+            insert_converter_using_as!(I64, I8, convert_i64_to_i8, converters);
+            insert_converter_using_as!(I32, I16, convert_i32_to_i16, converters);
+            insert_converter_using_as!(I64, I16, convert_i64_to_i16, converters);
+            insert_converter_using_as!(I64, I32, convert_i64_to_i32, converters);
+
+            insert_converter_using_as!(F64, F32, convert_f64_to_f32, converters);
 
             converters
         };
@@ -380,13 +410,36 @@ where
     to_typed.z = from_typed.z.into();
 }
 
-unsafe fn convert_generic_primitive<F, T>(from: &[u8], to: &mut [u8])
+unsafe fn convert_using_into<F, T>(from: &[u8], to: &mut [u8])
 where
     F: Into<T> + Copy,
     T: Copy,
 {
-    let from_typed = *(from.as_ptr() as *const F);
-    let to_typed = &mut *(to.as_mut_ptr() as *mut T);
-
-    *to_typed = from_typed.into();
+    let from_typed = (from.as_ptr() as *const F).read_unaligned();
+    (to.as_mut_ptr() as *mut T).write_unaligned(from_typed.into());
 }
+
+macro_rules! convert_using_as {
+    ($type_from:ident, $type_to:ident, $name:ident) => {
+        unsafe fn $name(from: &[u8], to: &mut [u8]) {
+            let from_typed = (from.as_ptr() as *const $type_from).read_unaligned();
+            (to.as_mut_ptr() as *mut $type_to).write_unaligned(from_typed as $type_to);
+        }
+    };
+}
+
+convert_using_as!(u16, u8, convert_u16_to_u8);
+convert_using_as!(u32, u8, convert_u32_to_u8);
+convert_using_as!(u64, u8, convert_u64_to_u8);
+convert_using_as!(u32, u16, convert_u32_to_u16);
+convert_using_as!(u64, u16, convert_u64_to_u16);
+convert_using_as!(u64, u32, convert_u64_to_u32);
+
+convert_using_as!(i16, i8, convert_i16_to_i8);
+convert_using_as!(i32, i8, convert_i32_to_i8);
+convert_using_as!(i64, i8, convert_i64_to_i8);
+convert_using_as!(i32, i16, convert_i32_to_i16);
+convert_using_as!(i64, i16, convert_i64_to_i16);
+convert_using_as!(i64, i32, convert_i64_to_i32);
+
+convert_using_as!(f64, f32, convert_f64_to_f32);

--- a/pasture-io/src/tiles3d/pnts_metadata.rs
+++ b/pasture-io/src/tiles3d/pnts_metadata.rs
@@ -39,6 +39,10 @@ impl PntsMetadata {
     pub fn points_length(&self) -> usize {
         self.points_length
     }
+
+    pub fn rtc_center(&self) -> Option<Vector3<f32>> {
+        self.rtc_center
+    }
 }
 
 impl Metadata for PntsMetadata {

--- a/pasture-io/src/tiles3d/pnts_writer.rs
+++ b/pasture-io/src/tiles3d/pnts_writer.rs
@@ -92,7 +92,9 @@ impl<W: Write + Seek> PntsWriter<W> {
         }
     }
 
-    /// Sets the given vector as the parameter for the `RTC_CENTER` semantic in the FeatureTable
+    /// Sets the given vector as the parameter for the `RTC_CENTER` semantic in the FeatureTable. As per the 3D Tiles specification,
+    /// points can be defined relative to a center point, which is given by the `RTC_CENTER` semantic. Setting this value however
+    /// **does not automatically translate points relative to this center!** This has to be done prior to calling `write`!
     pub fn set_rtc_center(&mut self, rtc_center: Vector3<f64>) {
         self.rtc_center = Some(rtc_center);
     }


### PR DESCRIPTION
The 3D Tiles PNTS format defines the `RTC_CENTER` property that can be used to store points in a local coordinate system. This PR provides the option to have a  `PNTSReader` automatically shift the points during reading from the local coordinate system to the global coordinate system by adding the value of `RTC_CENTER`. Since we don't always want this, it is an option on the `PNTSReader`. 

As an added bonus, I finally implemented the `PointBufferWriteableExt` extension trait, that provides methods for setting attributes and points, and a possibly very useful method `transform_attribute` that takes a closure through which all values of a single attribute can be modified. 