### PR TITLE
Fix GPU feature & Use wgpu v0.11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
+      run: cargo build --verbose --features gpu,io_gpu_examples
     - name: Run tests
       run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,3 @@
 [workspace]
 members = ["pasture-core", "pasture-io", "pasture-tools", "pasture-derive", "pasture-algorithms"]
+resolver = "2"

--- a/pasture-core/Cargo.toml
+++ b/pasture-core/Cargo.toml
@@ -24,7 +24,7 @@ itertools = "0.10.0"
 byteorder = "1.4.2"
 
 # GPU related
-wgpu = { version = "0.9.0", optional = true }
+wgpu = { version = "0.11.0", features = ["spirv"], optional = true }
 shaderc = { version = "0.7.2", optional = true }
 futures = { version = "0.3", optional = true }
 bytemuck = { version = "1.5.1", optional = true }

--- a/pasture-core/examples/gpu_interleaved.rs
+++ b/pasture-core/examples/gpu_interleaved.rs
@@ -38,7 +38,7 @@ mod ex {
         pub gps_time: f64,
     }
 
-    fn main() {
+    pub fn main() {
         futures::executor::block_on(run());
     }
 

--- a/pasture-core/examples/gpu_per_attribute.rs
+++ b/pasture-core/examples/gpu_per_attribute.rs
@@ -38,7 +38,7 @@ mod ex {
         pub gps_time: f64,
     }
 
-    fn main() {
+    pub fn main() {
         futures::executor::block_on(run());
     }
 

--- a/pasture-io/Cargo.toml
+++ b/pasture-io/Cargo.toml
@@ -46,4 +46,4 @@ name = "las_bench"
 harness = false
 
 [features]
-io_gpu_example = ["pasture-core/gpu", "crevice", "mint", "log", "env_logger", "futures", "bytemuck"]
+io_gpu_examples = ["pasture-core/gpu", "crevice", "mint", "log", "env_logger", "futures", "bytemuck"]

--- a/pasture-io/examples/gpu_io_interleaved.rs
+++ b/pasture-io/examples/gpu_io_interleaved.rs
@@ -10,7 +10,7 @@ mod ex {
     use pasture_io::las::{LASReader, LASWriter};
     use std::path::Path;
 
-    // To run this example you have to enable a feature flag: --features="io_gpu_example"
+    // To run this example you have to enable a feature flag: --features="io_gpu_examples"
 
     // log + env_logging give improved wgpu error messages.
     // See https://crates.io/crates/env_logger
@@ -35,7 +35,7 @@ mod ex {
     // of the additional padding, even with std430. This also leads to longer computation time.
     //
     // For these reasons you're probably better off sticking to the per-attribute format for now.
-    fn main() {
+    pub fn main() {
         env_logger::init();
 
         futures::executor::block_on(run());

--- a/pasture-io/examples/gpu_io_per_attribute.rs
+++ b/pasture-io/examples/gpu_io_per_attribute.rs
@@ -1,4 +1,4 @@
-#[cfg(io_gpu_example)]
+#[cfg(feature = "io_gpu_examples")]
 mod ex {
     use pasture_io::las::{LASReader, LASWriter};
     use std::path::Path;
@@ -8,13 +8,13 @@ mod ex {
     use pasture_core::layout::attributes;
     use pasture_core::gpu::GpuPointBufferPerAttribute;
     use crevice::std140::AsStd140;
-    
-    // To run this example you have to enable a feature flag: --features="io_gpu_example"
-    
+
+    // To run this example you have to enable a feature flag: --features="io_gpu_examples"
+
     // log + env_logging give improved wgpu error messages.
     // See https://crates.io/crates/env_logger
     extern crate log;
-    
+
     // Important: keep in mind that uniforms use a std140 alignment, so you might have to pad your data.
     // See: https://sotrh.github.io/learn-wgpu/showcase/alignment/#alignments
     // This example uses 'crevice' to take care of the alignment. An alternative would be 'glsl_layout'.
@@ -24,34 +24,34 @@ mod ex {
         point_count: u32,
         model: mint::ColumnMatrix4<f32>,
     }
-    
+
     async fn run() {
         // == Read LAS =================================================================================
-    
+
         let duration_start = chrono::Utc::now().timestamp_millis();
-    
+
         // If you decide to try out your own point cloud data, remember to adjust the shaders and the attributes.
         let path = Path::new("pasture-io/examples/in/10_points_format_1.las");
         let mut las_reader = match LASReader::from_path(path) {
             Ok(reader) => { println!("Ok {:?}", reader.header()); reader}
             Err(e) => { println!("Error: {}", e); return; }
         };
-    
+
         let count = las_reader.point_count().unwrap();
         let mut point_buffer = PerAttributeVecPointStorage::with_capacity(
             count,
             las_reader.get_default_point_layout().clone()
         );
         las_reader.read_into(&mut point_buffer, count).unwrap();
-    
+
         let duration_end = chrono::Utc::now().timestamp_millis();
         let elapsed_time = (duration_end - duration_start) as f32 / 1000.0;
         println!("Time elapsed (Read LAS): {}s", elapsed_time);
-    
+
         // == GPU ======================================================================================
-    
+
         let duration_start = chrono::Utc::now().timestamp_millis();
-    
+
         let device = gpu::Device::new(
             gpu::DeviceOptions {
                 device_power: gpu::DevicePower::High,
@@ -60,7 +60,7 @@ mod ex {
                 use_adapter_limits: true,
             }
         ).await;
-    
+
         let mut device = match device {
             Ok(d) => d ,
             Err(_) => {
@@ -68,7 +68,7 @@ mod ex {
                 return;
             }
         };
-    
+
         // Connects point buffer attributes to shader bindings
         let buffer_infos = vec![
             gpu::BufferInfoPerAttribute {
@@ -80,10 +80,10 @@ mod ex {
                 binding: 1,
             },
         ];
-    
+
         let point_count = point_buffer.len();
         println!("Number of points: {}", point_count);
-        
+
         // Fill uniform data and generate its bind group and bind group layout
         // Note the conversion to std140
         let point_uniform = PointUniform {
@@ -96,43 +96,43 @@ mod ex {
                 [0.0, 0.0, 0.0, 1.0],
             ]),
         }.as_std140();
-    
+
         let uniform_as_bytes: &[u8] = bytemuck::bytes_of(&point_uniform);
         let (uniform_bind_group_layout, uniform_bind_group) = device.create_uniform_bind_group(uniform_as_bytes, 0);
-    
+
         // Allocate memory for point buffer and queue it for upload onto the GPU
         let mut gpu_point_buffer = GpuPointBufferPerAttribute::new();
         gpu_point_buffer.malloc(point_count as u64, &buffer_infos, &mut device.wgpu_device);
         gpu_point_buffer.upload(&mut point_buffer, 0..point_count, &buffer_infos, &mut device.wgpu_device, &device.wgpu_queue);
-    
+
         // Here: GpuPointBuffer -> "set=0",
         //       PointUniform   -> "set=1"
         device.set_bind_group(0, gpu_point_buffer.bind_group_layout.as_ref().unwrap(), gpu_point_buffer.bind_group.as_ref().unwrap());
         device.set_bind_group(1, &uniform_bind_group_layout, &uniform_bind_group);
-    
+
         device.set_compute_shader_glsl(include_str!("shaders/io_per_attribute.comp"));
         device.compute(((point_count / 128) + 1) as u32, 1, 1);
-    
+
         gpu_point_buffer.download_into_per_attribute(&mut point_buffer, 0..point_count, &buffer_infos, &device.wgpu_device).await;
-    
+
         let duration_end = chrono::Utc::now().timestamp_millis();
         let elapsed_time = (duration_end - duration_start) as f32 / 1000.0;
         println!("Time elapsed (GPU): {}s", elapsed_time);
-    
+
         // == Write LAS ================================================================================
-    
+
         let duration_start = chrono::Utc::now().timestamp_millis();
-    
+
         let out_path = "pasture-io/examples/out/test_output.las";
         let las_writer = LASWriter::from_path_and_header(out_path, las_reader.header().clone());
         las_writer.unwrap().write(&point_buffer).unwrap();
-    
+
         let duration_end = chrono::Utc::now().timestamp_millis();
         let elapsed_time = (duration_end - duration_start) as f32 / 1000.0;
         println!("Time elapsed (Write LAS): {}s", elapsed_time);
     }
 
-    fn main() {
+    pub fn main() {
         env_logger::init();
 
         futures::executor::block_on(run());


### PR DESCRIPTION
Compiling the create with the gpu feature caused several errors.

With this we also build the gpu feature in CI to find future compile issues sooner. Running the gpu tests would be nice as well but isn't easily possible in CI I guess.

Not 100% certain about the implementation of the Vec4u8 matches but implementations were needed for compilation. 
The `resolver = "2"` bit is needed for wgpu >= v0.10.