### PR TITLE
Added into_inner method for LASWriter type

### DIFF
--- a/pasture-io/src/las/raw_writers.rs
+++ b/pasture-io/src/las/raw_writers.rs
@@ -151,6 +151,13 @@ impl<T: std::io::Write + std::io::Seek> RawLASWriter<T> {
         })
     }
 
+    /// Consumes this `RawLASWriter` and returns the underlying write type `T`. The data is flushed
+    /// before returning the writer
+    pub fn into_inner(mut self) -> Result<T> {
+        self.flush()?;
+        Ok(self.writer)
+    }
+
     /// Writes the current header to the start of the file
     fn write_header(&mut self) -> Result<()> {
         finalize_las_header(&mut self.current_header);
@@ -613,13 +620,6 @@ impl<T: std::io::Write + std::io::Seek> PointWriter for RawLASWriter<T> {
     }
 }
 
-impl<T: std::io::Write + std::io::Seek> Drop for RawLASWriter<T> {
-    fn drop(&mut self) {
-        self.flush()
-            .expect("RawLASWriter::drop: Could not flush point data");
-    }
-}
-
 pub(crate) struct RawLAZWriter<T: std::io::Write + std::io::Seek + Send + 'static> {
     writer: LasZipCompressor<'static, T>,
     default_layout: PointLayout,
@@ -701,6 +701,13 @@ impl<T: std::io::Write + std::io::Seek + Send + 'static> RawLAZWriter<T> {
                 .collect::<Result<Vec<_>, _>>()?,
             requires_flush: false,
         })
+    }
+
+    /// Consumes this `RawLASWriter` and returns the underlying write type `T`. The data is flushed
+    /// before returning the writer
+    pub fn into_inner(mut self) -> Result<T> {
+        self.do_flush()?;
+        Ok(self.writer.into_inner())
     }
 
     fn write_points_default_layout(&mut self, points: &dyn PointBuffer) -> Result<()> {
@@ -1153,10 +1160,10 @@ impl<T: std::io::Write + std::io::Seek + Send + 'static> RawLAZWriter<T> {
         Ok(())
     }
 
-    fn do_flush(&mut self) {
-        self.writer.done().expect("Could not flush LAZ contents");
-        self.write_evlrs().expect("Could not write LAZ EVLRs");
-        self.write_header().expect("Could not write LAZ header");
+    fn do_flush(&mut self) -> Result<()> {
+        self.writer.done()?;
+        self.write_evlrs()?;
+        self.write_header()
     }
 }
 
@@ -1170,17 +1177,11 @@ impl<T: std::io::Write + std::io::Seek + Send + 'static> PointWriter for RawLAZW
     }
 
     fn flush(&mut self) -> Result<()> {
-        panic!("Flush is not supported when writing LAZ files!");
+        self.do_flush()
     }
 
     fn get_default_point_layout(&self) -> &PointLayout {
         &self.default_layout
-    }
-}
-
-impl<T: std::io::Write + std::io::Seek + Send + 'static> Drop for RawLAZWriter<T> {
-    fn drop(&mut self) {
-        self.do_flush()
     }
 }
 
@@ -1235,6 +1236,7 @@ mod tests {
                         assert_eq!(expected_format, *writer.get_default_point_layout());
 
                         writer.write(test_data.as_ref())?;
+                        writer.flush()?;
                     }
 
                     {
@@ -1312,6 +1314,7 @@ mod tests {
                         )?;
 
                         writer.write(&expected_data)?;
+                        writer.flush()?;
                     }
 
                     {
@@ -1411,6 +1414,7 @@ mod tests {
                         assert_eq!(expected_format, *writer.get_default_point_layout());
 
                         writer.write(test_data.as_ref())?;
+                        writer.flush()?;
                     }
 
                     {
@@ -1489,6 +1493,7 @@ mod tests {
                         )?;
 
                         writer.write(&expected_data)?;
+                        writer.flush()?;
                     }
 
                     {
@@ -1578,20 +1583,4 @@ mod tests {
     laz_write_tests!(laz_write_1, 1, LasPointFormat1);
     laz_write_tests!(laz_write_2, 2, LasPointFormat2);
     laz_write_tests!(laz_write_3, 3, LasPointFormat3);
-
-    #[test]
-    #[should_panic]
-    fn test_raw_laz_writer_flush() {
-        let format = Format::new(0).unwrap();
-        let mut header_builder = Builder::from((1, 4));
-        header_builder.point_format = format.clone();
-
-        let mut writer = RawLAZWriter::from_write_and_header(
-            Cursor::new(vec![]),
-            header_builder.into_header().unwrap(),
-        )
-        .unwrap();
-
-        writer.flush().unwrap_or_default();
-    }
 }


### PR DESCRIPTION
This PR adds an `into_inner` method to the `LASWriter` type. This allows users to retrieve the `Write` type that they passed to the `LASWriter` when creating it using `from_writer_and_header`, similar to what `Cursor<T>` does for example. To enable this, the `LASWriter` type now has to carry type information of the underlying `Write` type, which sadly is a breaking API change. 