### PR TITLE
Fix precision problems when reading .pnts files

### DIFF
--- a/pasture-io/src/tiles3d/common.rs
+++ b/pasture-io/src/tiles3d/common.rs
@@ -73,6 +73,26 @@ pub fn json_arr_to_vec3f32(json_arr: &[Value]) -> Result<Vector3<f32>> {
     Ok(Vector3::new(x, y, z))
 }
 
+/// Converts an array of JSON Values into a Vector3<f64>
+pub fn json_arr_to_vec3f64(json_arr: &[Value]) -> Result<Vector3<f64>> {
+    if json_arr.len() != 3 {
+        bail!(
+            "JSON array must have length 3 to convert to Vector3<f32> (but has length {})",
+            json_arr.len()
+        )
+    }
+    let vals = json_arr
+        .iter()
+        .map(|v| v.as_f64().ok_or(anyhow!("Can't convert JSON value to f64")))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let x = vals[0];
+    let y = vals[1];
+    let z = vals[2];
+
+    Ok(Vector3::new(x, y, z))
+}
+
 pub fn json_arr_to_vec4u8(json_arr: &[Value]) -> Result<Vector4<u8>> {
     if json_arr.len() != 4 {
         bail!(

--- a/pasture-io/src/tiles3d/pnts_metadata.rs
+++ b/pasture-io/src/tiles3d/pnts_metadata.rs
@@ -10,7 +10,7 @@ use pasture_core::{
 #[derive(Clone, Debug)]
 pub struct PntsMetadata {
     points_length: usize,
-    rtc_center: Option<Vector3<f32>>,
+    rtc_center: Option<Vector3<f64>>,
     quantized_volume_offset: Option<Vector3<f32>>,
     quantized_volume_scale: Option<Vector3<f32>>,
     constant_rgba: Option<Vector4<u8>>,
@@ -20,7 +20,7 @@ pub struct PntsMetadata {
 impl PntsMetadata {
     pub fn new(
         points_length: usize,
-        rtc_center: Option<Vector3<f32>>,
+        rtc_center: Option<Vector3<f64>>,
         quantized_volume_offset: Option<Vector3<f32>>,
         quantized_volume_scale: Option<Vector3<f32>>,
         constant_rgba: Option<Vector4<u8>>,
@@ -40,7 +40,10 @@ impl PntsMetadata {
         self.points_length
     }
 
-    pub fn rtc_center(&self) -> Option<Vector3<f32>> {
+    /// Access the `RTC_CENTER` field of the metadata. Note that even though the 3D Tiles spec
+    /// explicitly says this is a 3-component vector of `float32` values, it makes no sense to
+    /// use the low-precision f32 type for this field, so pasture provides it as `Vector3<f64>`
+    pub fn rtc_center(&self) -> Option<Vector3<f64>> {
         self.rtc_center
     }
 }

--- a/pasture-io/src/tiles3d/pnts_reader.rs
+++ b/pasture-io/src/tiles3d/pnts_reader.rs
@@ -27,7 +27,7 @@ use crate::{
     tiles3d::{attributes::COLOR_RGBA, json_arr_to_vec3f32, json_arr_to_vec4u8},
 };
 
-use super::PntsMetadata;
+use super::{json_arr_to_vec3f64, PntsMetadata};
 
 /// Defines how the `PntsReader` reads positions if the `RTC_CENTER` point semantic is present
 #[derive(Copy, Clone, Debug)]
@@ -202,7 +202,7 @@ impl<R: BufRead + Seek> PntsReader<R> {
         let rtc_center = header
             .get("RTC_CENTER")
             .map(|entry| match entry {
-                FeatureTableValue::Array(array) => json_arr_to_vec3f32(&array),
+                FeatureTableValue::Array(array) => json_arr_to_vec3f64(&array),
                 _ => Err(anyhow!("RTC_CENTER value was no array entry")),
             })
             .transpose()?;
@@ -266,19 +266,18 @@ impl<R: BufRead + Seek> PntsReader<R> {
                 point_buffer.transform_attribute(
                     POSITION_3D.name(),
                     |_, position: &mut Vector3<f32>| {
-                        *position += rtc_center;
+                        *position = Vector3::new(
+                            (position.x as f64 + rtc_center.x) as f32,
+                            (position.y as f64 + rtc_center.y) as f32,
+                            (position.z as f64 + rtc_center.z) as f32,
+                        );
                     },
                 );
             } else {
-                let rtc_center_highp = Vector3::new(
-                    rtc_center.x as f64,
-                    rtc_center.y as f64,
-                    rtc_center.z as f64,
-                );
                 point_buffer.transform_attribute(
                     POSITION_3D.name(),
                     |_, position: &mut Vector3<f64>| {
-                        *position += rtc_center_highp;
+                        *position += rtc_center;
                     },
                 );
             }


### PR DESCRIPTION
Increases the precision of the `RTC_CENTER` field in the `PntsReader` so that as little precision as possible is lost when reading `.pnts` files. 