### PR TITLE
add checked attribute view and float generic in compute centroid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- Add `BorrowedBuffer::view_attribute_checked` that returns None rather than panicking if the data type does not match the requested one.
+- Require the user to specify the underlying floating point type of their point cloud's `POSITION_3D` when running `compute_centroid`.
+
 # 0.4.0 
 
 - Major overhaul of the buffer API in `pasture-core`. This is a breaking change for previous `pasture` versions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
-- Add `BorrowedBuffer::view_attribute_checked` that returns None rather than panicking if the data type does not match the requested one.
-- Require the user to specify the underlying floating point type of their point cloud's `POSITION_3D` when running `compute_centroid`.
+- Take an `AttributeView` instead of a `BorrowedBuffer` for `compute_centroid`.
 
 # 0.4.0 
 

--- a/pasture-algorithms/src/normal_estimation.rs
+++ b/pasture-algorithms/src/normal_estimation.rs
@@ -210,43 +210,19 @@ where
         return None;
     }
 
-    let mut centroid = Vector3::<F>::zeros();
-    let mut temp_centroid = Vector3::<F>::zeros();
-
-    let points_in_cloud = if is_dense(attribute_view) {
-        // add all points up
-        let points_in_cloud = attribute_view.len();
-        for point in attribute_view.into_iter() {
-            temp_centroid[0] += point.x;
-            temp_centroid[1] += point.y;
-            temp_centroid[2] += point.z;
-        }
-
-        // normalize over all points
-        centroid[0] = temp_centroid[0] / points_in_cloud.as_();
-        centroid[1] = temp_centroid[1] / points_in_cloud.as_();
-        centroid[2] = temp_centroid[2] / points_in_cloud.as_();
-        points_in_cloud
+    if is_dense(attribute_view) {
+        Some(attribute_view.into_iter().sum::<Vector3<F>>() / attribute_view.len().as_())
     } else {
+        let mut temp_centroid = Vector3::<F>::zeros();
         let mut points_in_cloud = 0;
         for point in attribute_view.into_iter() {
             if is_finite(&point) {
-                // add all points up
-                temp_centroid[0] += point.x;
-                temp_centroid[1] += point.y;
-                temp_centroid[2] += point.z;
+                temp_centroid += point;
                 points_in_cloud += 1;
             }
         }
-        points_in_cloud
-    };
-
-    // normalize over all points
-    centroid[0] = temp_centroid[0] / points_in_cloud.as_();
-    centroid[1] = temp_centroid[1] / points_in_cloud.as_();
-    centroid[2] = temp_centroid[2] / points_in_cloud.as_();
-
-    Some(centroid)
+        Some(temp_centroid / points_in_cloud.as_())
+    }
 }
 
 /// compute the covariance matrix for a given point cloud which is a measure of spread out the points are

--- a/pasture-core/src/containers/buffer_views.rs
+++ b/pasture-core/src/containers/buffer_views.rs
@@ -319,6 +319,16 @@ impl<'a, 'b, B: BorrowedBuffer<'a>, T: PrimitiveType> AttributeView<'a, 'b, B, T
         }
         attribute
     }
+
+    /// Get the length of the underlying buffer.
+    pub fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Check if the underlying buffer is empty.
+    pub fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
 }
 
 impl<'a, 'b, B: ColumnarBuffer<'a>, T: PrimitiveType> AttributeView<'a, 'b, B, T>
@@ -351,6 +361,17 @@ where
 
 impl<'a, 'b, B: BorrowedBuffer<'a> + 'a, T: PrimitiveType> IntoIterator
     for AttributeView<'a, 'b, B, T>
+{
+    type Item = T;
+    type IntoIter = AttributeIteratorByValue<'a, 'b, T, B>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        AttributeIteratorByValue::new(self.buffer, self.attribute.attribute_definition())
+    }
+}
+
+impl<'a, 'b, B: BorrowedBuffer<'a> + 'a, T: PrimitiveType> IntoIterator
+    for &AttributeView<'a, 'b, B, T>
 {
     type Item = T;
     type IntoIter = AttributeIteratorByValue<'a, 'b, T, B>;

--- a/pasture-core/src/containers/point_buffer.rs
+++ b/pasture-core/src/containers/point_buffer.rs
@@ -168,6 +168,29 @@ pub trait BorrowedBuffer<'a> {
         AttributeView::new(self, attribute)
     }
 
+    /// Gets a strongly typed view of the `attribute` of all points in this buffer
+    ///
+    /// Returns None if `attribute` is not part of the `PointLayout` of this buffer,
+    /// or if `T::data_type()` does not match the data type of the attribute within the buffer
+    fn view_attribute_checked<'b, T: PrimitiveType>(
+        &'b self,
+        attribute: &PointAttributeDefinition,
+    ) -> Option<AttributeView<'a, 'b, Self, T>>
+    where
+        Self: Sized,
+        'a: 'b,
+    {
+        self.point_layout()
+            .get_attribute(attribute)
+            .and_then(|member| {
+                if T::data_type() == member.datatype() {
+                    Some(AttributeView::new(self, attribute))
+                } else {
+                    None
+                }
+            })
+    }
+
     /// Like `view_attribute`, but allows `T::data_type()` to be different from the data type of  
     /// the `attribute` within this buffer.
     ///

--- a/pasture-core/src/containers/point_buffer.rs
+++ b/pasture-core/src/containers/point_buffer.rs
@@ -168,29 +168,6 @@ pub trait BorrowedBuffer<'a> {
         AttributeView::new(self, attribute)
     }
 
-    /// Gets a strongly typed view of the `attribute` of all points in this buffer
-    ///
-    /// Returns None if `attribute` is not part of the `PointLayout` of this buffer,
-    /// or if `T::data_type()` does not match the data type of the attribute within the buffer
-    fn view_attribute_checked<'b, T: PrimitiveType>(
-        &'b self,
-        attribute: &PointAttributeDefinition,
-    ) -> Option<AttributeView<'a, 'b, Self, T>>
-    where
-        Self: Sized,
-        'a: 'b,
-    {
-        self.point_layout()
-            .get_attribute(attribute)
-            .and_then(|member| {
-                if T::data_type() == member.datatype() {
-                    Some(AttributeView::new(self, attribute))
-                } else {
-                    None
-                }
-            })
-    }
-
     /// Like `view_attribute`, but allows `T::data_type()` to be different from the data type of  
     /// the `attribute` within this buffer.
     ///


### PR DESCRIPTION
#23 
Downside of this approach is that it requires the user to specify if their pointcloud has f32 or f64 precision.

If it's important, we can maintain backwards compatibility with some clever naming.

\Edit: for centroid, which I used as an example, we could get around that with a private generic function and a public function that always returns f64 and checks the data_type of the point cloud attribute at runtime.  I am not crazy about that solution though.