### PR TITLE
Optional SerDe support for certain types

### DIFF
--- a/pasture-core/Cargo.toml
+++ b/pasture-core/Cargo.toml
@@ -13,21 +13,26 @@ readme = "README.md"
 
 [dependencies]
 pasture-derive = {version = "=0.4.0", path = "../pasture-derive" }
-nalgebra = {version = "0.32", features = ["serde-serialize", "convert-bytemuck"] }
+nalgebra = {version = "0.32", features = ["convert-bytemuck"] }
 anyhow = "1.0.34"
 float-ord = "0.2.0"
 static_assertions = "1.1.0"
 lazy_static = "1.4.0"
-serde = { version = "1.0.119", features = ["derive"] }
+serde = { version = "1.0.193", features = ["derive"], optional = true }
 rayon = "1.5.0"
 itertools = "0.10.0"
 byteorder = "1.4.2"
 num-traits = "0.2.16"
 bytemuck = { version = "1.5.1", features = ["derive"] }
+uuid = {version = "1.6.1"}
 
 [dev-dependencies]
 rand = "0.8.2"
 criterion = "0.3"
+serde_json = "1.0.107"
+
+[features]
+serde = ["dep:serde", "nalgebra/serde-serialize", "uuid/serde"]
 
 [[bench]]
 name = "point_buffer_iterators_bench"

--- a/pasture-core/src/math/bounds.rs
+++ b/pasture-core/src/math/bounds.rs
@@ -3,10 +3,9 @@ use std::iter::FromIterator;
 use float_ord::FloatOrd;
 use nalgebra::{ClosedSub, Point3, Scalar, Vector3};
 
-use serde::Serialize;
-
 /// 3D axis-aligned bounding box
-#[derive(Debug, Clone, Copy, Serialize, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AABB<T: Scalar + PartialOrd> {
     min: Point3<T>,
     max: Point3<T>,

--- a/pasture-io/Cargo.toml
+++ b/pasture-io/Cargo.toml
@@ -34,6 +34,7 @@ bitfield = "0.14"
 num-traits = "0.2.16"
 memmap2 = "0.7.1"
 lazy_static = "1.4.0"
+nalgebra = { version = "0.32", features = ["serde-serialize"]}
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
 - Feature flag "serde" in pasture-core
 - Derive serde::Serialize / serde::Deserialize for the following types:
   - pasture_core::layout::PointAttributeDataType
   - pasture_core::layout::PointAttributeDefinition
   - pasture_core::layout::PointAttributeMember
   - pasture_core::layout::PointLayout
   - pasture_core::math::AABB
 - Turned the 'name' field of PointAttributeDataType::Custom into a uuid::Uuid