### PR TITLE
Views on trait objects

### DIFF
--- a/pasture-algorithms/benches/convexhull_bench.rs
+++ b/pasture-algorithms/benches/convexhull_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use pasture_algorithms::convexhull;
 use pasture_core::{
-    containers::{BorrowedMutBuffer, HashMapBuffer, VectorBuffer},
+    containers::{BorrowedMutBufferExt, HashMapBuffer, VectorBuffer},
     layout::PointType,
     nalgebra::Vector3,
 };

--- a/pasture-algorithms/examples/reprojection_example.rs
+++ b/pasture-algorithms/examples/reprojection_example.rs
@@ -1,7 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 mod ex {
     use pasture_algorithms::reprojection::reproject_point_cloud_within;
-    use pasture_core::containers::{BorrowedBuffer, VectorBuffer};
+    use pasture_core::containers::{BorrowedBufferExt, VectorBuffer};
     use pasture_core::nalgebra::Vector3;
     use pasture_derive::PointType;
 

--- a/pasture-algorithms/examples/segmentation_example.rs
+++ b/pasture-algorithms/examples/segmentation_example.rs
@@ -2,7 +2,7 @@ use pasture_algorithms::segmentation::{
     ransac_line_par, ransac_line_serial, ransac_plane_par, ransac_plane_serial,
 };
 use pasture_core::{
-    containers::{BorrowedMutBuffer, HashMapBuffer},
+    containers::{BorrowedMutBufferExt, HashMapBuffer},
     layout::attributes::INTENSITY,
     nalgebra::Vector3,
 };

--- a/pasture-algorithms/src/bounds.rs
+++ b/pasture-algorithms/src/bounds.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use pasture_core::{
-    containers::BorrowedBuffer,
+    containers::{BorrowedBuffer, BorrowedBufferExt},
     layout::attributes::POSITION_3D,
     math::AABB,
     nalgebra::{Point3, Vector3},

--- a/pasture-algorithms/src/convexhull.rs
+++ b/pasture-algorithms/src/convexhull.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use pasture_core::containers::BorrowedBuffer;
+use pasture_core::containers::{BorrowedBuffer, BorrowedBufferExt};
 use pasture_core::{layout::attributes::POSITION_3D, nalgebra::Vector3};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
@@ -464,7 +464,7 @@ mod tests {
     use crate::convexhull;
     use anyhow::Result;
     use pasture_core::{
-        containers::{BorrowedBuffer, BorrowedMutBuffer, HashMapBuffer},
+        containers::{BorrowedBuffer, BorrowedBufferExt, BorrowedMutBufferExt, HashMapBuffer},
         layout::attributes::POSITION_3D,
         layout::PointType,
         nalgebra::Vector3,

--- a/pasture-algorithms/src/minmax.rs
+++ b/pasture-algorithms/src/minmax.rs
@@ -1,5 +1,5 @@
 use pasture_core::{
-    containers::BorrowedBuffer,
+    containers::{BorrowedBuffer, BorrowedBufferExt},
     layout::{PointAttributeDefinition, PrimitiveType},
     math::MinMax,
 };

--- a/pasture-algorithms/src/normal_estimation.rs
+++ b/pasture-algorithms/src/normal_estimation.rs
@@ -2,7 +2,9 @@
 use core::panic;
 use kd_tree::{self, KdPoint, KdTree};
 use num_traits::{self};
-use pasture_core::containers::{BorrowedBuffer, BorrowedMutBuffer, HashMapBuffer, OwningBuffer};
+use pasture_core::containers::{
+    BorrowedBuffer, BorrowedBufferExt, BorrowedMutBufferExt, HashMapBuffer, OwningBuffer,
+};
 use pasture_core::layout::{attributes::POSITION_3D, PointType};
 use pasture_core::nalgebra::{DMatrix, Vector3};
 use std::result::Result;

--- a/pasture-algorithms/src/reprojection.rs
+++ b/pasture-algorithms/src/reprojection.rs
@@ -1,7 +1,7 @@
 use std::ffi::CString;
 
 use anyhow::Result;
-use pasture_core::containers::BorrowedMutBuffer;
+use pasture_core::containers::{BorrowedBufferExt, BorrowedMutBuffer, BorrowedMutBufferExt};
 use pasture_core::math::AABB;
 use pasture_core::nalgebra::{Point3, Vector3};
 

--- a/pasture-algorithms/src/reprojection.rs
+++ b/pasture-algorithms/src/reprojection.rs
@@ -272,7 +272,7 @@ mod tests {
 
         reproject_point_cloud_within(&mut interleaved, "EPSG:4326", "EPSG:3309");
 
-        let results = vec![
+        let results = [
             Vector3::new(12185139.590523569, 7420953.944297638, 0.0),
             Vector3::new(11104667.534080556, 7617693.973680517, 0.0),
             Vector3::new(11055663.927418157, 5832081.512011217, 2.0),
@@ -318,7 +318,7 @@ mod tests {
 
         reproject_point_cloud_between(&mut interleaved, &mut attribute, "EPSG:4326", "EPSG:3309");
 
-        let results = vec![
+        let results = [
             Vector3::new(12185139.590523569, 7420953.944297638, 0.0),
             Vector3::new(11104667.534080556, 7617693.973680517, 0.0),
             Vector3::new(11055663.927418157, 5832081.512011217, 2.0),

--- a/pasture-algorithms/src/segmentation.rs
+++ b/pasture-algorithms/src/segmentation.rs
@@ -2,7 +2,7 @@ use std::vec;
 
 use pasture_core::{
     layout::attributes::POSITION_3D,
-    nalgebra::Vector3, containers::BorrowedBuffer,
+    nalgebra::Vector3, containers::{BorrowedBuffer, BorrowedBufferExt},
 };
 use rand::Rng;
 use rayon::prelude::*;

--- a/pasture-algorithms/src/voxel_grid.rs
+++ b/pasture-algorithms/src/voxel_grid.rs
@@ -1,7 +1,9 @@
 use std::{collections::HashMap, u16};
 
 use pasture_core::{
-    containers::{BorrowedBuffer, OwningBuffer, UntypedPoint, UntypedPointBuffer},
+    containers::{
+        BorrowedBuffer, BorrowedBufferExt, OwningBuffer, UntypedPoint, UntypedPointBuffer,
+    },
     layout::{
         attributes::{self, POSITION_3D},
         PointAttributeDataType, PointAttributeDefinition, PointLayout,
@@ -691,7 +693,7 @@ mod tests {
 
     use crate::voxel_grid::voxelgrid_filter;
     use pasture_core::{
-        containers::{BorrowedBuffer, HashMapBuffer, MakeBufferFromLayout},
+        containers::{BorrowedBuffer, BorrowedBufferExt, HashMapBuffer, MakeBufferFromLayout},
         layout::attributes,
         nalgebra::Vector3,
     };

--- a/pasture-algorithms/src/voxel_grid.rs
+++ b/pasture-algorithms/src/voxel_grid.rs
@@ -21,9 +21,9 @@ pub struct Voxel {
 /// finds leaf of point p by iterating over the marked axis
 fn find_leaf(
     p: Vector3<f64>,
-    markers_x: &Vec<f64>,
-    markers_y: &Vec<f64>,
-    markers_z: &Vec<f64>,
+    markers_x: &[f64],
+    markers_y: &[f64],
+    markers_z: &[f64],
 ) -> (usize, usize, usize) {
     let mut index_x = 0;
     let mut index_y = 0;

--- a/pasture-core/benches/layout_conversion_bench.rs
+++ b/pasture-core/benches/layout_conversion_bench.rs
@@ -4,8 +4,8 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use nalgebra::Vector3;
 use pasture_core::{
     containers::{
-        ColumnarBuffer, HashMapBuffer, InterleavedBuffer, MakeBufferFromLayout, OwningBuffer,
-        VectorBuffer,
+        BorrowedBufferExt, ColumnarBuffer, HashMapBuffer, InterleavedBuffer, MakeBufferFromLayout,
+        OwningBuffer, VectorBuffer,
     },
     layout::{conversion::BufferLayoutConverter, PointType},
 };

--- a/pasture-core/benches/point_buffer_iterators_bench.rs
+++ b/pasture-core/benches/point_buffer_iterators_bench.rs
@@ -1,8 +1,8 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use pasture_core::{
     containers::{
-        BorrowedBuffer, BorrowedMutBuffer, ColumnarBuffer, HashMapBuffer, InterleavedBuffer,
-        VectorBuffer,
+        BorrowedBuffer, BorrowedBufferExt, BorrowedMutBufferExt, ColumnarBuffer, HashMapBuffer,
+        InterleavedBuffer, VectorBuffer,
     },
     layout::attributes::POSITION_3D,
     layout::PointType,

--- a/pasture-core/benches/point_buffer_iterators_bench.rs
+++ b/pasture-core/benches/point_buffer_iterators_bench.rs
@@ -109,6 +109,12 @@ fn points_ref_iterator_performance_small_type<'a>(buffer: &'a impl InterleavedBu
     }
 }
 
+fn points_ref_iterator_performance_with_trait_object<'a>(buffer: &'a dyn InterleavedBuffer<'a>) {
+    for point in buffer.view::<CustomPointTypeSmall>().iter() {
+        criterion::black_box(point.position);
+    }
+}
+
 fn attribute_iterator_performance_opaque_buffer<'a, T: PrimitiveType + Default>(
     buffer: &'a impl BorrowedBuffer<'a>,
     attribute: &PointAttributeDefinition,
@@ -193,6 +199,11 @@ fn bench(c: &mut Criterion) {
     );
     c.bench_function("points_ref_iterator_small_type", |b| {
         b.iter(|| points_ref_iterator_performance_small_type(&dummy_points_small_interleaved))
+    });
+    c.bench_function("points_ref_iterator_small_type_with_trait_object", |b| {
+        b.iter(|| {
+            points_ref_iterator_performance_with_trait_object(&dummy_points_small_interleaved)
+        })
     });
 
     c.bench_function("attribute_iterator_interleaved_opaque_buffer", |b| {

--- a/pasture-core/examples/basic_point_buffers.rs
+++ b/pasture-core/examples/basic_point_buffers.rs
@@ -70,6 +70,19 @@ fn main() {
         // is what 'interleaved' means: We can get (mutable) references to the strongly typed point data, since all data
         // for a single point is stored contiguously in memory!
 
+        // We can also access individual attributes by using `view_attribute`:
+        for position in buffer.view_attribute::<Vector3<f64>>(&POSITION_3D) {
+            println!("{position:?}");
+        }
+
+        buffer.transform_attribute(&INTENSITY, |_index: usize, intensity: u16| -> u16 {
+            intensity * 2
+        });
+
+        // Where interleaved memory layout allows references to whole points, it disallows references to individual
+        // attribute values (as these might not be correctly aligned). Therefore, we can only access attributes by
+        // value using a `VectorBuffer`, which requires a copy operation
+
         // Just like arrays and vectors, our buffers can also be sliced. Unfortunately, the current constraints of the `Index`
         // trait prevent us from implementing it for the pasture point buffers, so we can't slice our buffers using the
         // `[range]` syntax. Instead, use the `slice` and `slice_mut` methods:

--- a/pasture-core/examples/basic_point_buffers.rs
+++ b/pasture-core/examples/basic_point_buffers.rs
@@ -1,5 +1,5 @@
 use pasture_core::containers::{
-    BorrowedBuffer, BorrowedMutBuffer, HashMapBuffer, MakeBufferFromLayout, SliceBuffer,
+    BorrowedBufferExt, BorrowedMutBufferExt, HashMapBuffer, MakeBufferFromLayout, SliceBuffer,
     SliceBufferMut,
 };
 use pasture_core::nalgebra::Vector3;

--- a/pasture-core/examples/layout_conversion.rs
+++ b/pasture-core/examples/layout_conversion.rs
@@ -1,4 +1,4 @@
-use pasture_core::containers::{BorrowedBuffer, OwningBuffer, VectorBuffer};
+use pasture_core::containers::{BorrowedBuffer, BorrowedBufferExt, OwningBuffer, VectorBuffer};
 use pasture_core::layout::attributes::{COLOR_RGB, POSITION_3D};
 use pasture_core::layout::conversion::BufferLayoutConverter;
 use pasture_core::layout::{PointAttributeDataType, PointType};

--- a/pasture-core/examples/point_buffer_traits_explained.rs
+++ b/pasture-core/examples/point_buffer_traits_explained.rs
@@ -1,0 +1,239 @@
+use nalgebra::Vector3;
+use pasture_core::{
+    containers::{
+        BorrowedBuffer, BorrowedBufferExt, BorrowedMutBuffer, BorrowedMutBufferExt, ColumnarBuffer,
+        ColumnarBufferMut, ExternalMemoryBuffer, HashMapBuffer, InterleavedBuffer,
+        InterleavedBufferMut, OwningBuffer, VectorBuffer,
+    },
+    layout::{
+        attributes::{INTENSITY, POSITION_3D},
+        PointType,
+    },
+};
+use pasture_derive::PointType;
+
+#[repr(C, packed)]
+#[derive(Copy, Clone, PointType, Debug, bytemuck::NoUninit, bytemuck::AnyBitPattern, PartialEq)]
+struct SimplePoint {
+    #[pasture(BUILTIN_POSITION_3D)]
+    pub position: Vector3<f64>,
+    #[pasture(BUILTIN_INTENSITY)]
+    pub intensity: u16,
+}
+
+fn get_default_points() -> Vec<SimplePoint> {
+    vec![
+        SimplePoint {
+            position: Vector3::new(1.0, 2.0, 3.0),
+            intensity: 123,
+        },
+        SimplePoint {
+            position: Vector3::new(4.0, 5.0, 6.0),
+            intensity: 456,
+        },
+    ]
+}
+
+fn main() {
+    // pasture defines a bunch of traits for point buffers. Some of these are explained implicitly in the
+    // `basic_point_buffers` example. In this example, we will look at all the traits in more detail. In
+    // addition you are encouraged to read the module documentation of `pasture_core::containers` as well
+
+    let points = get_default_points();
+
+    // pasture currently provides the following point buffer implementations:
+    let mut vector_buffer: VectorBuffer = points.iter().copied().collect();
+    let mut hashmap_buffer: HashMapBuffer = points.iter().copied().collect();
+
+    let memory = vec![0; SimplePoint::layout().size_of_point_entry() as usize];
+    let external_memory_buffer = ExternalMemoryBuffer::new(&memory, SimplePoint::layout());
+
+    // What makes these buffers different, and when would you use which one? Let's ignore the `ExternalMemoryBuffer`
+    // for now and focus on `VectorBuffer` and `HashMapBuffer`. If you look at the trait implementations for
+    // `VectorBuffer` (https://docs.rs/pasture-core/latest/pasture_core/containers/struct.VectorBuffer.html#trait-implementations)
+    // you will see that it implements many different traits with `Buffer` in their name. There are two hierarchies
+    // of point buffer traits in pasture: One defines the memory ownership model of the buffer, the other defines the
+    // memory layout of points within the buffer. First we will look at the memory ownership traits, starting with
+    // `BorrowedBuffer`:
+
+    // `BorrowedBuffer` is the most abstract trait. It makes no assumptions about the memory layout of points
+    // and only assumes that the memory of the point buffer is borrowed somehow. Given this, how can we access point
+    // data within a `BorrowedBuffer`? A point cloud in pasture is defined as a collection of tuples of attribute
+    // values (where each tuple has the same attributes). So we need ways to access specific tuples (i.e. points) as
+    // well as specific tuple elements (i.e. attributes of a point). This is precisely what `BorrowedBuffer` does,
+    // as shown in the following code (using explicit trait function names instead of the dot operator for clarity):
+
+    let mut memory_for_one_point: Vec<u8> =
+        vec![0; SimplePoint::layout().size_of_point_entry() as usize];
+    BorrowedBuffer::get_point(&vector_buffer, 0, &mut memory_for_one_point);
+    BorrowedBuffer::get_point(&hashmap_buffer, 0, &mut memory_for_one_point);
+
+    let mut memory_for_one_position: Vec<u8> = vec![0; POSITION_3D.size() as usize];
+    BorrowedBuffer::get_attribute(
+        &vector_buffer,
+        &POSITION_3D,
+        0,
+        &mut memory_for_one_position,
+    );
+    BorrowedBuffer::get_attribute(
+        &hashmap_buffer,
+        &POSITION_3D,
+        0,
+        &mut memory_for_one_position,
+    );
+
+    // By design, all buffer traits in pasture work on raw binary data, typically in the form of byte slices (`[u8]`).
+    // This enables handling point clouds where the number and types of point attributes is only known at runtime.
+    // The `view` methods shown in the `basic_point_buffers` example provide more convenient ways to get point and
+    // attribute data with strong typing, instead of byte slices. Under the hood, views use the raw `get_...` APIs from
+    // the point buffer traits, such as `BorrowedBuffer`.
+
+    // There are some caveats with the API from `BorrowedBuffer`:
+    // 1) Accessing a point or an attribute of a point requires a copy into some buffer
+    // 2) We can't mutate points or point attributes
+    // These issues correspond to a lack of knowledge about the memory layout (1) and memory ownership (2) of the
+    // point buffer. We require copy operations because `BorrowedBuffer` doesn't know what the actual memory layout
+    // of the point data is, point attributes might be stored at non-adjacent memory locations, which might even be
+    // unaligned, so getting a reference to point/attribute data is impossible.
+    // Mutation is impossible because `BorrowedBuffer` assumes that the underlying memory is borrowed immutably!
+    // Introduce `BorrowedMutBuffer`:
+
+    let new_point = SimplePoint {
+        position: Vector3::new(1.1, 2.2, 3.3),
+        intensity: 555,
+    };
+    unsafe {
+        let raw_memory_of_new_point = bytemuck::bytes_of(&new_point);
+        BorrowedMutBuffer::set_point(&mut vector_buffer, 0, raw_memory_of_new_point);
+    }
+
+    let new_intensity: i16 = 1024;
+    unsafe {
+        let raw_memory_of_new_intensity = bytemuck::bytes_of(&new_intensity);
+        BorrowedMutBuffer::set_attribute(
+            &mut vector_buffer,
+            &INTENSITY,
+            0,
+            raw_memory_of_new_intensity,
+        );
+    }
+
+    // With `BorrowedMutBuffer`, we know that the underlying memory is borrowed mutably, so we can mutate the point
+    // and attribute data. These functions also operate on byte slices, and in this case pasture can't check whether
+    // the incoming byte slice contains valid memory, so these functions are unsafe! In principle, since all pasture
+    // `PrimitiveType`s implement `bytemuck::AnyBitPattern`, it is not possible to create undefined behavior with
+    // these `set_...` functions, so the unsafety is more of a marker to the user that care must be taken when using
+    // these functions.
+
+    // Notice that `BorrowedMutBuffer` has more strict guarantees about the memory ownership than `BorrowedBuffer`,
+    // i.e. any type implementing `BorrowedMutBuffer` also implements `BorrowedBuffer`. The API of `BorrowedMutBuffer`
+    // is still restricted, for example resizing of the memory is not supported. For this, there is the last trait in
+    // the memory ownership hierarchy in pasture: `OwningBuffer`:
+
+    let old_size = vector_buffer.len();
+    unsafe {
+        let bytes_of_new_point = bytemuck::bytes_of(&new_point);
+        OwningBuffer::push_points(&mut vector_buffer, bytes_of_new_point);
+    }
+    assert_eq!(old_size + 1, vector_buffer.len());
+
+    // Instead of using these raw APIs, using views is often the better choice, and there are corresponding functions
+    // on all the views:
+
+    {
+        let point_view = hashmap_buffer.view::<SimplePoint>();
+        assert_eq!(point_view.at(0), points[0]);
+
+        let positions_view = hashmap_buffer.view_attribute::<Vector3<f64>>(&POSITION_3D);
+        let expected_position = points[0].position;
+        assert_eq!(positions_view.at(0), expected_position);
+    }
+    {
+        let mut point_mut_view = hashmap_buffer.view_mut::<SimplePoint>();
+        point_mut_view.set_at(0, points[1]);
+        point_mut_view.push_point(points[1]);
+    }
+
+    // Now we look at the other hierarchy of point buffer traits, which relates to the memory layout of buffers.
+    // Again the base trait is `BorrowedBuffer`, which makes no assumptions about the memory layout, which means
+    // that point attributes can be stored at arbitrary addresses, or even computed on the fly. Beyond that, pasture
+    // knows two specific memory layouts, called *interleaved* and *columnar*. This can be illustrated using the
+    // `SimplePoint` type at the top of this file. It has two attributes: A position, as a `Vector3<f64>`, and an
+    // intensity, as an `i16`. Given four points, the memory layouts will look like this:
+
+    // Interleaved  : [p_1,i_1,p_2,i_2,p_3,i_3,p_4,i_4]
+    // Columnar     : [p_1,p_2,p_3,p_4,i_1,i_2,i_3,i_4]
+
+    // The interleaved memory layout stores all data for a single point together in memory, which makes it possible
+    // to obtain a reference to memory for an individual point, or even for a range of points. This is the memory
+    // layout you would expect a `Vec<SimplePoint>` to have.
+    // The columnar memory layout stores all data for the same attribute together in memory, which makes it possible
+    // to obtain a referecne to memory for an individual attribute of a point, or range of points.
+    // The interleaved memory layout is sometimes called 'array-of-structs', whereas the columnar memory layout is
+    // sometimes called 'struct-of-arrays', to illustrate how these layouts might be implemented in a C-like language.
+
+    // pasture defines traits for buffers that guarantee a specific memory layout. The first is `InterleavedBuffer`:
+
+    let _first_point: &[u8] = InterleavedBuffer::get_point_ref(&vector_buffer, 0);
+    let _first_two_points: &[u8] = InterleavedBuffer::get_point_range_ref(&vector_buffer, 0..2);
+
+    // `VectorBuffer` supports interleaved memory layout, so we can get references to the raw point memory without
+    // any copying. This is also why it is possible to iterate over the points in an `InterleavedBuffer` by reference:
+
+    for point_ref in vector_buffer.view::<SimplePoint>().iter() {
+        println!("Point ref: {point_ref:?}");
+    }
+
+    // For mutating data, there is also `InterleavedBufferMut`:
+
+    let _first_point_mut: &mut [u8] = InterleavedBufferMut::get_point_mut(&mut vector_buffer, 0);
+
+    // Columnar memory layout buffers will implement `ColumnarBuffer`:
+
+    let _first_position: &[u8] =
+        ColumnarBuffer::get_attribute_ref(&hashmap_buffer, &POSITION_3D, 0);
+    let _all_intensities: &[u8] = ColumnarBuffer::get_attribute_range_ref(
+        &hashmap_buffer,
+        &INTENSITY,
+        0..hashmap_buffer.len(),
+    );
+
+    // `HashMapBuffer` supports columnar memory layout, so we can get references to the raw memory of a specific
+    // attribute, or range of that attribute. Where we could iterate over points by reference in an `InterleavedBuffer`,
+    // we can iterate over attributes by reference in a `ColumnarBuffer`:
+
+    for position_ref in hashmap_buffer
+        .view_attribute::<Vector3<f64>>(&POSITION_3D)
+        .iter()
+    {
+        println!("Position ref: {position_ref}");
+    }
+
+    // There is also `ColumnarBufferMut` for mutating attribute values:
+
+    let _first_position_mut: &mut [u8] =
+        ColumnarBufferMut::get_attribute_mut(&mut hashmap_buffer, &POSITION_3D, 0);
+
+    // Note that interleaved and columnar memory layouts are generally mutually exclusive. There are hypothetical edge
+    // cases, such as a buffer holding just one point, but even then the attributes might be misaligned, preventing
+    // access by reference to attribute memory. Unfortunately, the Rust language does not support negative trait bounds,
+    // which make some code more complicated/less flexible than it could be. In particular we cannot do compile-time dispatch
+    // based on the memory layout of a given buffer type. Instead, we have to do that at runtime, like this:
+
+    fn accepts_any_buffer<'a, B: BorrowedBuffer<'a>>(buffer: &'a B) {
+        // We can't statically dispatch to an implementation for `B: InterleavedBuffer` or `B: ColumnarBuffer`, but
+        // we can use runtime polymorphism for this
+        if let Some(interleaved) = buffer.as_interleaved() {
+            for point in interleaved.view::<SimplePoint>().iter() {
+                println!("{point:?}");
+            }
+        } else if let Some(columnar) = buffer.as_columnar() {
+            for position in columnar.view_attribute::<Vector3<f64>>(&POSITION_3D).iter() {
+                println!("{position}");
+            }
+        }
+    }
+    accepts_any_buffer(&vector_buffer);
+    accepts_any_buffer(&hashmap_buffer);
+    accepts_any_buffer(&external_memory_buffer);
+}

--- a/pasture-core/examples/point_layout.rs
+++ b/pasture-core/examples/point_layout.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use pasture_core::containers::{BorrowedMutBuffer, MakeBufferFromLayout, VectorBuffer};
+use pasture_core::containers::{BorrowedMutBufferExt, MakeBufferFromLayout, VectorBuffer};
 use pasture_core::layout::{
     attributes, PointAttributeDataType, PointAttributeDefinition, PointLayout, PointType,
 };

--- a/pasture-core/src/containers/attribute_iterators.rs
+++ b/pasture-core/src/containers/attribute_iterators.rs
@@ -6,7 +6,7 @@ use super::point_buffer::{BorrowedBuffer, ColumnarBuffer, ColumnarBufferMut};
 
 /// An iterator over strongly typed attribute data in a point buffer. Returns attribute data
 /// by value and makes assumptions about the memory layout of the underlying buffer
-pub struct AttributeIteratorByValue<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a>>
+pub struct AttributeIteratorByValue<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a> + ?Sized>
 where
     'a: 'b,
 {
@@ -16,7 +16,9 @@ where
     _phantom: PhantomData<&'a T>,
 }
 
-impl<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a>> AttributeIteratorByValue<'a, 'b, T, B> {
+impl<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a> + ?Sized>
+    AttributeIteratorByValue<'a, 'b, T, B>
+{
     pub(crate) fn new(buffer: &'b B, attribute: &PointAttributeDefinition) -> Self {
         Self {
             attribute_member: buffer
@@ -30,7 +32,7 @@ impl<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a>> AttributeIteratorByValue<'
     }
 }
 
-impl<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a>> Iterator
+impl<'a, 'b, T: PrimitiveType, B: BorrowedBuffer<'a> + ?Sized> Iterator
     for AttributeIteratorByValue<'a, 'b, T, B>
 {
     type Item = T;
@@ -68,7 +70,7 @@ pub struct AttributeIteratorByRef<'a, T: PrimitiveType> {
 }
 
 impl<'a, T: PrimitiveType> AttributeIteratorByRef<'a, T> {
-    pub(crate) fn new<'b, B: ColumnarBuffer<'b>>(
+    pub(crate) fn new<'b, B: ColumnarBuffer<'b> + ?Sized>(
         buffer: &'a B,
         attribute: &PointAttributeDefinition,
     ) -> Self
@@ -110,7 +112,7 @@ pub struct AttributeIteratorByMut<'a, T: PrimitiveType> {
 }
 
 impl<'a, T: PrimitiveType> AttributeIteratorByMut<'a, T> {
-    pub(crate) fn new<'b, B: ColumnarBufferMut<'b>>(
+    pub(crate) fn new<'b, B: ColumnarBufferMut<'b> + ?Sized>(
         buffer: &'a mut B,
         attribute: &PointAttributeDefinition,
     ) -> Self
@@ -152,12 +154,10 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use crate::{
-        containers::{BorrowedMutBuffer, HashMapBuffer},
+        containers::{BorrowedBufferExt, BorrowedMutBufferExt, HashMapBuffer},
         layout::attributes::POSITION_3D,
         test_utils::{CustomPointTypeSmall, DefaultPointDistribution},
     };
-
-    use super::*;
 
     #[test]
     #[allow(clippy::iter_nth_zero)]

--- a/pasture-core/src/containers/buffer_views.rs
+++ b/pasture-core/src/containers/buffer_views.rs
@@ -19,9 +19,10 @@ use super::{
 };
 
 /// A strongly typed view over the point data of a buffer. This allows accessing the point data in
-/// the buffer using type `T` instead of only through raw memory (i.e. as `&[u8]`). This type makes
-/// no assumptions about the memory layout of the underlying buffer, so it only provides access to
-/// the point data by value. The `PointView` supports no type conversion, so `T::layout()` must match
+/// the buffer using type `T` instead of only through raw memory (i.e. as `&[u8]`).
+/// Depending on the memory layout of the buffer type `B`, this view supports accessing the point data
+/// only by value (for non-interleaved buffers) or by immutable borrow (for interleaved buffers).
+/// The `PointView` supports no type conversion, so `T::layout()` must match
 /// the `PointLayout` of the buffer. You cannot create instances of `PointView` directly but instead
 /// have to use [`BorrowedBuffer::view`] function and its variations, which perform the necessary type
 /// checks internally!
@@ -142,7 +143,7 @@ impl<'a, 'b, B: BorrowedBuffer<'a> + ?Sized + 'a, T: PointType + Eq> Eq
 
 /// Like [`PointView`], but provides mutable access to the strongly typed point data. For buffers with unknown
 /// memory layout, this means that you have to use [`PointViewMut::set_at`], but if the underlying buffer
-/// implements [`InterleavedBufferMut`], you can also get a mutable borrow the a strongly typed point!
+/// implements [`InterleavedBufferMut`], you can also access strongly-typed points by mutable borrow!
 #[derive(Debug)]
 pub struct PointViewMut<'a, 'b, B: BorrowedMutBuffer<'a> + ?Sized, T: PointType>
 where

--- a/pasture-core/src/containers/point_iterators.rs
+++ b/pasture-core/src/containers/point_iterators.rs
@@ -5,7 +5,7 @@ use crate::layout::PointType;
 use super::point_buffer::{BorrowedBuffer, InterleavedBuffer, InterleavedBufferMut};
 
 /// Iterator over strongly typed points by value
-pub struct PointIteratorByValue<'a, 'b, T: PointType, B: BorrowedBuffer<'a>>
+pub struct PointIteratorByValue<'a, 'b, T: PointType, B: BorrowedBuffer<'a> + ?Sized>
 where
     'a: 'b,
 {
@@ -14,7 +14,7 @@ where
     _phantom: PhantomData<&'a T>,
 }
 
-impl<'a, 'b, T: PointType, B: BorrowedBuffer<'a>> From<&'b B>
+impl<'a, 'b, T: PointType, B: BorrowedBuffer<'a> + ?Sized> From<&'b B>
     for PointIteratorByValue<'a, 'b, T, B>
 {
     fn from(value: &'b B) -> Self {
@@ -26,7 +26,9 @@ impl<'a, 'b, T: PointType, B: BorrowedBuffer<'a>> From<&'b B>
     }
 }
 
-impl<'a, 'b, T: PointType, B: BorrowedBuffer<'a>> Iterator for PointIteratorByValue<'a, 'b, T, B> {
+impl<'a, 'b, T: PointType, B: BorrowedBuffer<'a> + ?Sized> Iterator
+    for PointIteratorByValue<'a, 'b, T, B>
+{
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -53,7 +55,8 @@ pub struct PointIteratorByRef<'a, T: PointType> {
     current_index: usize,
 }
 
-impl<'a, 'b, T: PointType, B: InterleavedBuffer<'b>> From<&'a B> for PointIteratorByRef<'a, T>
+impl<'a, 'b, T: PointType, B: InterleavedBuffer<'b> + ?Sized> From<&'a B>
+    for PointIteratorByRef<'a, T>
 where
     'b: 'a,
 {
@@ -92,7 +95,7 @@ pub struct PointIteratorByMut<'a, T: PointType> {
     _phantom: PhantomData<T>,
 }
 
-impl<'a, 'b, T: PointType, B: InterleavedBufferMut<'b>> From<&'a mut B>
+impl<'a, 'b, T: PointType, B: InterleavedBufferMut<'b> + ?Sized> From<&'a mut B>
     for PointIteratorByMut<'a, T>
 where
     'b: 'a,
@@ -133,11 +136,9 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use crate::{
-        containers::{BorrowedMutBuffer, VectorBuffer},
+        containers::{BorrowedBufferExt, BorrowedMutBufferExt, VectorBuffer},
         test_utils::{CustomPointTypeSmall, DefaultPointDistribution},
     };
-
-    use super::*;
 
     #[test]
     #[allow(clippy::iter_nth_zero)]

--- a/pasture-core/src/layout/conversion/buffer_conversion.rs
+++ b/pasture-core/src/layout/conversion/buffer_conversion.rs
@@ -673,7 +673,7 @@ mod tests {
     use rand::{thread_rng, Rng};
 
     use crate::{
-        containers::{HashMapBuffer, VectorBuffer},
+        containers::{BorrowedBufferExt, HashMapBuffer, VectorBuffer},
         layout::{
             attributes::{CLASSIFICATION, POSITION_3D, RETURN_NUMBER},
             PointType,

--- a/pasture-core/src/layout/conversion/buffer_conversion.rs
+++ b/pasture-core/src/layout/conversion/buffer_conversion.rs
@@ -191,15 +191,13 @@ impl<'a> BufferLayoutConverter<'a> {
     /// If `from_attribute` is not part of the source `PointLayout`.
     /// If `to_attribute` is not part of the target `PointLayout`.
     /// If `T::data_type()` does not match `to_attribute.datatype()`.
-    pub fn set_custom_mapping_with_transformation<T: PrimitiveType, F: Fn(T) -> T>(
+    pub fn set_custom_mapping_with_transformation<T: PrimitiveType, F: Fn(T) -> T + 'static>(
         &mut self,
         from_attribute: &PointAttributeDefinition,
         to_attribute: &PointAttributeDefinition,
         transform_fn: F,
         apply_to_source_attribute: bool,
-    ) where
-        F: 'static,
-    {
+    ) {
         let from_attribute_member = self
             .from_layout
             .get_attribute(from_attribute)

--- a/pasture-core/src/layout/point_layout.rs
+++ b/pasture-core/src/layout/point_layout.rs
@@ -1064,7 +1064,6 @@ mod tests {
         PointType,
     };
     use pasture_derive::PointType;
-    use serde_json::json;
 
     #[derive(
         Debug, PointType, Copy, Clone, PartialEq, bytemuck::NoUninit, bytemuck::AnyBitPattern,

--- a/pasture-core/src/layout/point_layout.rs
+++ b/pasture-core/src/layout/point_layout.rs
@@ -7,29 +7,6 @@ use uuid::Uuid;
 
 use crate::math::Alignable;
 
-mod private {
-    use super::*;
-
-    pub trait Sealed {}
-
-    impl Sealed for u8 {}
-    impl Sealed for u16 {}
-    impl Sealed for u32 {}
-    impl Sealed for u64 {}
-    impl Sealed for i8 {}
-    impl Sealed for i16 {}
-    impl Sealed for i32 {}
-    impl Sealed for i64 {}
-    impl Sealed for f32 {}
-    impl Sealed for f64 {}
-    impl Sealed for bool {}
-    impl Sealed for Vector3<u8> {}
-    impl Sealed for Vector3<u16> {}
-    impl Sealed for Vector3<f32> {}
-    impl Sealed for Vector3<f64> {}
-    impl Sealed for Vector4<u8> {}
-}
-
 /// Possible data types for individual point attributes
 ///
 /// # Why no `bool` anymore?

--- a/pasture-core/src/layout/point_layout.rs
+++ b/pasture-core/src/layout/point_layout.rs
@@ -515,13 +515,13 @@ pub mod attributes {
         datatype: PointAttributeDataType::U8,
     };
 
-    /// Attribute definition for a scan direction flag. Default datatype is Bool
+    /// Attribute definition for a scan direction flag. Default datatype is U8
     pub const SCAN_DIRECTION_FLAG: PointAttributeDefinition = PointAttributeDefinition {
         name: Cow::Borrowed("ScanDirectionFlag"),
         datatype: PointAttributeDataType::U8,
     };
 
-    /// Attribute definition for an edge of flight line flag. Default datatype is Bool
+    /// Attribute definition for an edge of flight line flag. Default datatype is U8
     pub const EDGE_OF_FLIGHT_LINE: PointAttributeDefinition = PointAttributeDefinition {
         name: Cow::Borrowed("EdgeOfFlightLine"),
         datatype: PointAttributeDataType::U8,

--- a/pasture-io/benches/las_bench.rs
+++ b/pasture-io/benches/las_bench.rs
@@ -4,7 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use las::Builder;
 use pasture_core::{
     containers::{
-        BorrowedBuffer, BorrowedMutBuffer, HashMapBuffer, MakeBufferFromLayout, OwningBuffer,
+        BorrowedBuffer, BorrowedMutBufferExt, HashMapBuffer, MakeBufferFromLayout, OwningBuffer,
         VectorBuffer,
     },
     layout::PointType,

--- a/pasture-io/examples/fast_las_parsing.rs
+++ b/pasture-io/examples/fast_las_parsing.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::{bail, Result};
 use memmap2::{Advice, MmapOptions};
 use pasture_core::{
-    containers::{BorrowedBuffer, ExternalMemoryBuffer},
+    containers::{BorrowedBufferExt, ExternalMemoryBuffer},
     layout::{attributes::POSITION_3D, PointAttributeDataType},
     nalgebra::Vector3,
 };

--- a/pasture-io/examples/las_io.rs
+++ b/pasture-io/examples/las_io.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use pasture_core::{
-    containers::{BorrowedBuffer, HashMapBuffer, VectorBuffer},
+    containers::{BorrowedBuffer, BorrowedBufferExt, HashMapBuffer, VectorBuffer},
     layout::{attributes::POSITION_3D, PointLayout},
     nalgebra::Vector3,
 };

--- a/pasture-io/examples/simple_filtering.rs
+++ b/pasture-io/examples/simple_filtering.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::Result;
 use pasture_core::{
-    containers::{BorrowedBuffer, InterleavedBuffer, VectorBuffer},
+    containers::{BorrowedBufferExt, InterleavedBuffer, VectorBuffer},
     layout::attributes::CLASSIFICATION,
 };
 use pasture_io::{base::PointReader, las::LASReader};

--- a/pasture-io/examples/simple_io.rs
+++ b/pasture-io/examples/simple_io.rs
@@ -25,7 +25,7 @@ fn main() -> Result<()> {
             println!("({};{};{})", position.x, position.y, position.z);
         }
     } else {
-        println!("Point cloud files has no positions!");
+        println!("Point cloud file has no positions!");
     }
 
     // Writing all points from a buffer to a file is also easy: Just call `write_all`

--- a/pasture-io/examples/simple_io.rs
+++ b/pasture-io/examples/simple_io.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use pasture_core::{
-    containers::{BorrowedBuffer, VectorBuffer},
+    containers::{BorrowedBuffer, BorrowedBufferExt, VectorBuffer},
     layout::attributes::POSITION_3D,
     nalgebra::Vector3,
 };

--- a/pasture-io/examples/write_3dtiles.rs
+++ b/pasture-io/examples/write_3dtiles.rs
@@ -2,7 +2,7 @@ use std::{fs::File, io::BufWriter};
 
 use anyhow::Result;
 use pasture_core::{
-    containers::{BorrowedMutBuffer, HashMapBuffer},
+    containers::{BorrowedMutBufferExt, HashMapBuffer},
     layout::PointType,
     math::AABB,
     nalgebra::{Point3, Vector3},

--- a/pasture-io/src/ascii/raw_reader.rs
+++ b/pasture-io/src/ascii/raw_reader.rs
@@ -347,7 +347,7 @@ mod tests {
     };
     use anyhow::Result;
     use pasture_core::containers::{
-        BorrowedBuffer, MakeBufferFromLayout, OwningBuffer, VectorBuffer,
+        BorrowedBufferExt, MakeBufferFromLayout, OwningBuffer, VectorBuffer,
     };
     use pasture_core::layout::{attributes, PointType};
     use pasture_core::nalgebra::Vector3;

--- a/pasture-io/src/ascii/raw_writer.rs
+++ b/pasture-io/src/ascii/raw_writer.rs
@@ -4,8 +4,7 @@ use anyhow::{Context, Result};
 use pasture_core::containers::{BorrowedBuffer, UntypedPoint, UntypedPointSlice};
 use pasture_core::layout::{attributes, PointLayout};
 use pasture_core::nalgebra::Vector3;
-// combined trait to handle the PointWriter trait aswell as the AsciiFormat trait
-pub trait PointWriterFormatting: PointWriter + AsciiFormat {}
+
 pub trait AsciiFormat {
     fn set_delimiter(&mut self, delimiter: &str);
     fn set_precision(&mut self, precision: usize);
@@ -38,7 +37,6 @@ impl<T: std::io::Write + std::io::Seek> AsciiFormat for RawAsciiWriter<T> {
         self.precision = precision;
     }
 }
-impl<T: std::io::Write + std::io::Seek> PointWriterFormatting for RawAsciiWriter<T> {}
 
 impl<T: std::io::Write + std::io::Seek> PointWriter for RawAsciiWriter<T> {
     fn write<'a, B: BorrowedBuffer<'a>>(&mut self, points: &'a B) -> anyhow::Result<()> {

--- a/pasture-io/src/las/las_writer.rs
+++ b/pasture-io/src/las/las_writer.rs
@@ -130,7 +130,7 @@ mod tests {
 
     use las::{point::Format, Builder};
     use pasture_core::{
-        containers::{MakeBufferFromLayout, OwningBuffer, VectorBuffer},
+        containers::{BorrowedBufferExt, MakeBufferFromLayout, OwningBuffer, VectorBuffer},
         layout::PointType,
         nalgebra::Vector3,
     };

--- a/pasture-io/src/las/test_util.rs
+++ b/pasture-io/src/las/test_util.rs
@@ -3,7 +3,9 @@ use std::{borrow::Cow, ops::Range, path::PathBuf};
 use anyhow::Result;
 use las_rs::point::Format;
 use pasture_core::{
-    containers::{BorrowedBuffer, BorrowedMutBuffer, HashMapBuffer, OwningBuffer},
+    containers::{
+        BorrowedBuffer, BorrowedBufferExt, BorrowedMutBufferExt, HashMapBuffer, OwningBuffer,
+    },
     layout::{attributes, FieldAlignment, PointAttributeDataType, PointAttributeDefinition},
     math::AABB,
     nalgebra::{Point3, Vector3},

--- a/pasture-io/src/tiles3d/pnts_reader.rs
+++ b/pasture-io/src/tiles3d/pnts_reader.rs
@@ -8,7 +8,7 @@ use std::{
 
 use anyhow::{anyhow, bail, Context, Result};
 use pasture_core::{
-    containers::BorrowedMutBuffer,
+    containers::{BorrowedMutBuffer, BorrowedMutBufferExt},
     layout::{
         attributes::{COLOR_RGB, NORMAL, POSITION_3D},
         conversion::get_converter_for_attributes,

--- a/pasture-io/src/tiles3d/pnts_reader.rs
+++ b/pasture-io/src/tiles3d/pnts_reader.rs
@@ -401,7 +401,7 @@ mod tests {
 
     use super::*;
     use pasture_core::{
-        containers::{BorrowedBuffer, HashMapBuffer, VectorBuffer},
+        containers::{BorrowedBufferExt, HashMapBuffer, VectorBuffer},
         layout::PointType,
     };
     use pasture_derive::PointType;

--- a/pasture-io/src/tiles3d/pnts_writer.rs
+++ b/pasture-io/src/tiles3d/pnts_writer.rs
@@ -414,7 +414,7 @@ mod tests {
 
     use super::*;
     use pasture_core::{
-        containers::VectorBuffer,
+        containers::{BorrowedBufferExt, VectorBuffer},
         layout::PointType,
         nalgebra::{Vector3, Vector4},
     };

--- a/pasture-io/src/tiles3d/pnts_writer.rs
+++ b/pasture-io/src/tiles3d/pnts_writer.rs
@@ -452,7 +452,7 @@ mod tests {
     fn test_write_pnts_default_layout() -> Result<()> {
         let mut cursor = Cursor::new(Vec::<u8>::new());
 
-        let test_data = vec![
+        let test_data = [
             PntsDefaultPoint {
                 position: Vector3::new(1.0, 2.0, 3.0),
                 color: Vector3::new(10, 20, 30),
@@ -507,7 +507,7 @@ mod tests {
     fn test_write_pnts_custom_layout() -> Result<()> {
         let mut cursor = Cursor::new(Vec::<u8>::new());
 
-        let test_data = vec![
+        let test_data = [
             PntsCustomLayout {
                 position: Vector3::new(1.0, 2.0, 3.0),
                 color: Vector3::new(0x1111, 0x2222, 0x3333),

--- a/pasture-io/src/tiles3d/pnts_writer.rs
+++ b/pasture-io/src/tiles3d/pnts_writer.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 use pasture_core::{
     containers::{
         BorrowedBuffer, BorrowedMutBuffer, ColumnarBuffer, HashMapBuffer, MakeBufferFromLayout,
-        OwningBuffer,
+        OwningBuffer, OwningBufferExt,
     },
     layout::{
         attributes::{COLOR_RGB, NORMAL, POSITION_3D},

--- a/pasture-io/tests/common/mod.rs
+++ b/pasture-io/tests/common/mod.rs
@@ -10,7 +10,6 @@ use pasture_io::las::{
     LasPointFormat9,
 };
 use rand::{prelude::Distribution, Rng};
-use static_assertions::const_assert_eq;
 
 const RETURN_NUMBER_REGULAR_BITMASK: u8 = 0b111;
 const RETURN_NUMBER_EXTENDED_BITMASK: u8 = 0b1111;
@@ -50,59 +49,6 @@ impl ExtendedFlags {
         pub edge_of_flight_line, set_edge_of_flight_line: 15;
     }
 }
-
-#[derive(Debug, Copy, Clone, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
-#[repr(C, packed)]
-pub struct RawLASPointFormat5 {
-    x: i32,
-    y: i32,
-    z: i32,
-    intensity: u16,
-    flags: BasicFlags,
-    classification: u8,
-    scan_angle_rank: i8,
-    user_data: u8,
-    point_source_id: u16,
-    gps_time: f64,
-    red: u16,
-    green: u16,
-    blue: u16,
-    wave_packet_desriptor_index: u8,
-    byte_offset_to_waveform_data: u64,
-    waveform_packet_size: u32,
-    return_point_waveform_location: f32,
-    dx: f32,
-    dy: f32,
-    dz: f32,
-}
-const_assert_eq!(63, std::mem::size_of::<RawLASPointFormat5>());
-
-#[derive(Debug, Copy, Clone, bytemuck::AnyBitPattern, bytemuck::NoUninit)]
-#[repr(C, packed)]
-pub struct RawLASPointFormat10 {
-    x: i32,
-    y: i32,
-    z: i32,
-    intensity: u16,
-    flags: ExtendedFlags,
-    classification: u8,
-    user_data: u8,
-    scan_angle: i16,
-    point_source_id: u16,
-    gps_time: f64,
-    red: u16,
-    green: u16,
-    blue: u16,
-    nir: u16,
-    wave_packet_desriptor_index: u8,
-    byte_offset_to_waveform_data: u64,
-    waveform_packet_size: u32,
-    return_point_waveform_location: f32,
-    dx: f32,
-    dy: f32,
-    dz: f32,
-}
-const_assert_eq!(67, std::mem::size_of::<RawLASPointFormat10>());
 
 /// Distribution for sampling random LAS points
 pub struct TestLASPointDistribution;

--- a/pasture-io/tests/common/mod.rs
+++ b/pasture-io/tests/common/mod.rs
@@ -1,6 +1,6 @@
 use bitfield::{bitfield_bitrange, bitfield_fields};
 use pasture_core::{
-    containers::BorrowedBuffer,
+    containers::{BorrowedBuffer, BorrowedBufferExt},
     layout::{PointAttributeDataType, PointAttributeDefinition, PrimitiveType},
     nalgebra::{Vector3, Vector4},
 };

--- a/pasture-io/tests/las_io.rs
+++ b/pasture-io/tests/las_io.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use common::TestLASPointDistribution;
 use itertools::Itertools;
 use pasture_core::{
-    containers::{BorrowedBuffer, HashMapBuffer, VectorBuffer},
+    containers::{BorrowedBuffer, BorrowedBufferExt, HashMapBuffer, VectorBuffer},
     layout::{
         attributes::{CLASSIFICATION, NORMAL, POSITION_3D},
         PointType,

--- a/pasture-io/tests/las_io.rs
+++ b/pasture-io/tests/las_io.rs
@@ -1,4 +1,4 @@
-use std::io::Cursor;
+use std::io::{Cursor, Seek, SeekFrom};
 
 use anyhow::{Context, Result};
 use common::TestLASPointDistribution;
@@ -346,5 +346,51 @@ fn test_write_large_file_with_custom_format() -> Result<()> {
         .context("Writing large LAS file with custom format failed")?;
     write_large_file_with_custom_format::<ComplexPointTypeWithConversions>(COUNT, true)
         .context("Writing large LAZ file with custom format failed")?;
+    Ok(())
+}
+
+#[test]
+fn test_las_laz_readers_are_equivalent() -> Result<()> {
+    // Test that writing and reading points as LAS and as LAZ gives the same result
+    let rng = thread_rng();
+    let expected_points = rng
+        .sample_iter::<LasPointFormat0, _>(TestLASPointDistribution)
+        .take(345)
+        .collect::<VectorBuffer>();
+
+    let point_layout = LasPointFormat0::layout();
+
+    let mut las_buffer: Cursor<Vec<u8>> = Cursor::new(Vec::default());
+    let mut laz_buffer: Cursor<Vec<u8>> = Cursor::new(Vec::default());
+
+    {
+        let mut writer = LASWriter::from_writer_and_point_layout(las_buffer, &point_layout, false)?;
+        writer.write(&expected_points)?;
+        writer.flush()?;
+        las_buffer = writer.into_inner()?;
+    }
+
+    {
+        let mut writer = LASWriter::from_writer_and_point_layout(laz_buffer, &point_layout, true)?;
+        writer.write(&expected_points)?;
+        writer.flush()?;
+        laz_buffer = writer.into_inner()?;
+    }
+
+    let points_from_las_file = {
+        las_buffer.seek(SeekFrom::Start(0))?;
+        let mut reader = LASReader::from_read(las_buffer, false, false)?;
+        reader.read::<VectorBuffer>(reader.remaining_points())?
+    };
+
+    let points_from_laz_file = {
+        laz_buffer.seek(SeekFrom::Start(0))?;
+        let mut reader = LASReader::from_read(laz_buffer, true, false)?;
+        reader.read::<VectorBuffer>(reader.remaining_points())?
+    };
+
+    assert_eq!(expected_points, points_from_las_file);
+    assert_eq!(expected_points, points_from_laz_file);
+
     Ok(())
 }


### PR DESCRIPTION
Enables point and attribute views on trait objects (e.g. `dyn BorrowedBuffer`, `dyn InterleavedBuffer` etc.). This closes a gap in conjunction with the `as_interleaved` and `as_columnar` functions on the `BorrowedBuffer` trait, and makes code like this possible:

```Rust
fn accepts_any_buffer<'a, B: BorrowedBuffer<'a>>(buffer: &'a B) {
    if let Some(interleaved) = buffer.as_interleaved() {
        for point in interleaved.view::<SimplePoint>().iter() {
            println!("{point:?}");
        }
    } else if let Some(columnar) = buffer.as_columnar() {
        for position in columnar.view_attribute::<Vector3<f64>>(&POSITION_3D).iter() {
            println!("{position}");
        }
    }
}
``` 

Also made some traits objects-safe that weren't before.